### PR TITLE
chore: remove happy path debug logging

### DIFF
--- a/src/ConnectorsExtension.js
+++ b/src/ConnectorsExtension.js
@@ -139,7 +139,7 @@ ConnectorsExtension.prototype.getContextPadEntries = function(element) {
             appendMenu.open(element, position).then(result => {
 
               if (!result) {
-                return console.log('append-anything :: user canceled');
+                return;
               }
 
               const {
@@ -161,7 +161,11 @@ ConnectorsExtension.prototype.getContextPadEntries = function(element) {
                 : createStart;
 
               append(event, element, newElement);
-            }).catch(err => console.warn(err));
+            }).catch(error => {
+              if (error !== 'user-canceled') {
+                console.error('append-anything :: error', error);
+              }
+            });
           }
         }
       };

--- a/src/append-menu/AppendMenu.js
+++ b/src/append-menu/AppendMenu.js
@@ -100,7 +100,7 @@ AppendMenu.prototype.open = function(element, position) {
   }).then((element) => {
 
     if (!element) {
-      return Promise.reject('user canceled');
+      return Promise.reject('user-canceled');
     }
 
     return element;

--- a/src/element-template-chooser/ElementTemplateChooser.js
+++ b/src/element-template-chooser/ElementTemplateChooser.js
@@ -45,11 +45,9 @@ export default function ElementTemplateChooser(
     this.open(templates).then(template => {
       this._applyTemplate(element, template);
     }).catch(err => {
-      if (err === 'user-canceled') {
-        console.log('elementTemplate.select :: user canceled');
+      if (err !== 'user-canceled') {
+        console.error('elementTemplate.select :: error', err);
       }
-
-      console.error('elementTemplate.select', err);
     });
   });
 }

--- a/src/replace-menu/ReplaceMenu.js
+++ b/src/replace-menu/ReplaceMenu.js
@@ -120,8 +120,10 @@ ReplaceMenu.prototype.open = function(element, position) {
     className: 'cmd-replace-menu',
     element,
     position
-  }).finally(() => {
-    console.log('replace menu closed');
+  }).catch((error) => {
+    if (error !== 'user-canceled') {
+      console.error('replaceMenu.open :: error', error);
+    }
   });
 };
 


### PR DESCRIPTION
Do not `console.log` during happy path. `console.error` async errors though.