### PR TITLE
Template categories + search

### DIFF
--- a/example/app.js
+++ b/example/app.js
@@ -26,6 +26,8 @@ import exampleXML from './newDiagram.bpmn';
 import EMAIL_TEMPLATES from './.camunda/element-templates/sendgrid-connector.json';
 import REST_TEMPLATES from './.camunda/element-templates/http-json-connector.json';
 
+import './style.css';
+
 const TEMPLATES = [ ...EMAIL_TEMPLATES, ...REST_TEMPLATES ];
 
 const url = new URL(window.location.href);

--- a/example/index.html
+++ b/example/index.html
@@ -9,8 +9,6 @@
   <link rel="stylesheet" href="vendor/bpmn-js-properties-panel/dist/assets/properties-panel.css" />
   <link rel="stylesheet" href="vendor/bpmn-js-properties-panel/dist/assets/element-templates.css" />
   <link rel="stylesheet" href="vendor/@ibm/plex/css/ibm-plex.min.css" />
-
-  <link rel="stylesheet" href="style.css" />
 </head>
 
 <body>

--- a/example/style.css
+++ b/example/style.css
@@ -8,6 +8,10 @@
   --font-family: var(--font-family);
 }
 
+.cmd-change-menu {
+  --change-menu-header-font-weight: 500;
+}
+
 html, body, #canvas {
   width: 100%;
   height: 100%;

--- a/src/append-menu/AppendMenu.js
+++ b/src/append-menu/AppendMenu.js
@@ -44,13 +44,17 @@ AppendMenu.prototype._getTemplateEntries = function(element) {
     const {
       id,
       name,
-      description
+      description,
+      category,
+      search
     } = template;
 
     return {
       name,
       description,
       id: `append-template-${id}`,
+      category,
+      search,
       action: () => {
         return this._elementTemplates.createElement(template);
       }
@@ -151,7 +155,8 @@ function AppendMenuComponent(props) {
       const search = [
         template.name && 'connector' || '',
         template.name, template.description || '',
-        template.label || ''
+        template.label || '',
+        template.search || ''
       ].join('---').toLowerCase();
 
       return value.toLowerCase().split(/\s/g).every(
@@ -256,7 +261,14 @@ function AppendMenuComponent(props) {
       </div>
 
       <ul class="cmd-change-menu__results" ref=${ resultsRef }>
-        ${templates.map(template => html`
+        ${templates.map((template, idx) => html`
+          ${ categoryChanged(template, templates[idx - 1]) && html`
+            <li
+              key=${ template.category.id }
+              class="cmd-change-menu__entry_header"
+            >${ template.category.name }</li>
+          ` }
+
           <li
             key=${template.id}
             class=${ clsx('cmd-change-menu__entry', { selected: template === selectedTemplate }) }
@@ -295,4 +307,15 @@ function AppendMenuComponent(props) {
       </ul>
     </div>
   `;
+}
+
+
+// helpers ////////////
+
+function categoryChanged(templateA, templateB) {
+
+  const categoryA = templateA && templateA.category;
+  const categoryB = templateB && templateB.category;
+
+  return (categoryA && categoryA.id) !== (categoryB && categoryB.id);
 }

--- a/src/change-menu/ChangeMenu.css
+++ b/src/change-menu/ChangeMenu.css
@@ -9,6 +9,8 @@
   left: 0;
   z-index: 200;
 
+  line-height: 1;
+
   --color-white: #fff;
   --color-black-opacity-10: hsla(0, 0%, 0%, 10%);
   --color-black-opacity-25: hsla(0, 0%, 0%, 25%);
@@ -32,12 +34,13 @@
   --change-menu-shadow-color: var(--color-black-opacity-25);
 
   --text-color: #22242A;
-  --text-muted-color: #818698;
+  --text-muted-color: #707585;
   --text-size-base: 14px;
   --text-size-small: 14px;
   --text-line-height: 21px;
 
-  line-height: 1;
+  --change-menu-category-color: var(--text-muted-color);
+  --change-menu-header-font-weight: bolder;
 }
 
 .cmd-change-menu__backdrop {
@@ -108,7 +111,7 @@
 
 .cmd-change-menu__title {
   font-size: 14px;
-  font-weight: 500;
+  font-weight: var(--change-menu-header-font-weight);
   flex: 1;
   margin: 0;
 }
@@ -145,12 +148,12 @@
 }
 
 .cmd-change-menu__entry_header {
-  font-weight: 500;
-  color: #666;
+  font-weight: var(--change-menu-header-font-weight);
+  color: var(--change-menu-category-color);
 }
 
 .cmd-change-menu__entry_header:not(:first-child) {
-  margin-top: 6px;
+  margin-top: 8px;
 }
 
 .cmd-change-menu__muted-entry {

--- a/src/change-menu/ChangeMenu.css
+++ b/src/change-menu/ChangeMenu.css
@@ -137,10 +137,20 @@
 }
 
 .cmd-change-menu__entry,
-.cmd-change-menu__muted-entry {
+.cmd-change-menu__muted-entry,
+.cmd-change-menu__entry_header {
   padding: 5px 7px;
   cursor: default;
   border-radius: 4px;
+}
+
+.cmd-change-menu__entry_header {
+  font-weight: 500;
+  color: #666;
+}
+
+.cmd-change-menu__entry_header:not(:first-child) {
+  margin-top: 6px;
 }
 
 .cmd-change-menu__muted-entry {

--- a/src/element-template-chooser/ElementTemplateChooser.js
+++ b/src/element-template-chooser/ElementTemplateChooser.js
@@ -109,7 +109,9 @@ function TemplateComponent(props) {
       }
 
       return [
-        template.name, template.description || ''
+        template.name,
+        template.description || '',
+        template.search || ''
       ].join('---').toLowerCase().includes(value.toLowerCase());
     };
 
@@ -189,7 +191,7 @@ function TemplateComponent(props) {
   return html`
     <div class="cmd-change-menu__header">
       <h3 class="cmd-change-menu__title">
-        Choose task template
+        Choose element template
       </h3>
     </div>
 
@@ -208,7 +210,15 @@ function TemplateComponent(props) {
       </div>
 
       <ul class="cmd-change-menu__results" ref=${ resultsRef }>
-        ${templates.map(template => html`
+        ${templates.map((template, idx) => html`
+
+          ${ categoryChanged(template, templates[idx - 1]) && html`
+            <li
+              key=${ template.category.id }
+              class="cmd-change-menu__entry_header"
+            >${ template.category.name }</li>
+          ` }
+
           <li
             key=${template.id}
             class=${ clsx('cmd-change-menu__entry', { selected: template === selectedTemplate }) }
@@ -246,4 +256,15 @@ function TemplateComponent(props) {
       </ul>
     </div>
   `;
+}
+
+
+// helpers ////////////
+
+function categoryChanged(templateA, templateB) {
+
+  const categoryA = templateA && templateA.category;
+  const categoryB = templateB && templateB.category;
+
+  return (categoryA && categoryA.id) !== (categoryB && categoryB.id);
 }

--- a/src/replace-menu/ReplaceMenu.js
+++ b/src/replace-menu/ReplaceMenu.js
@@ -51,7 +51,12 @@ ReplaceMenu.prototype._getTemplateEntries = function(element) {
     const {
       id,
       name,
-      description
+      description,
+      search,
+      category = {
+        id: 'templates',
+        name: 'Templates'
+      }
     } = template;
 
     /*
@@ -66,6 +71,8 @@ ReplaceMenu.prototype._getTemplateEntries = function(element) {
     return {
       name,
       description,
+      search,
+      category,
       id: `replace-template-${id}`,
       action: () => {
         this._applyTemplate(element, template);
@@ -166,8 +173,10 @@ function ReplaceMenuComponent(props) {
 
       const search = [
         template.name && 'connector' || '',
-        template.name, template.description || '',
-        template.label || ''
+        template.name,
+        template.description || '',
+        template.label || '',
+        template.search || ''
       ].join('---').toLowerCase();
 
       return value.toLowerCase().split(/\s/g).every(
@@ -278,7 +287,15 @@ function ReplaceMenuComponent(props) {
     </div>
 
     <ul class="cmd-change-menu__results" ref=${ resultsRef }>
-      ${templates.map(template => html`
+      ${templates.map((template, idx) => html`
+
+        ${ categoryChanged(template, templates[idx - 1]) && html`
+          <li
+            key=${ template.category.id }
+            class="cmd-change-menu__entry_header"
+          >${ template.category.name }</li>
+        ` }
+
         <li
           key=${template.id}
           class=${ clsx('cmd-change-menu__entry', { selected: template === selectedTemplate }) }
@@ -316,4 +333,15 @@ function ReplaceMenuComponent(props) {
     </ul>
   </div>
   `;
+}
+
+
+// helpers ////////////
+
+function categoryChanged(templateA, templateB) {
+
+  const categoryA = templateA && templateA.category;
+  const categoryB = templateB && templateB.category;
+
+  return (categoryA && categoryA.id) !== (categoryB && categoryB.id);
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,7 +26,7 @@ module.exports = {
   plugins: [
     new CopyPlugin({
       patterns: [
-        { from: '*.{html,css}', context: 'example', to: '.' },
+        { from: '*.html', context: 'example', to: '.' },
         { from: 'bpmn-js/dist/assets/**/*', context: 'node_modules', to: './vendor' },
         { from: 'bpmn-js-properties-panel/dist/assets/**/*', context: 'node_modules', to: './vendor' },
         { from: '@ibm/plex/{css/ibm-plex.min.css,IBM-Plex-Sans/fonts/{complete,split}/woff2/**}', context: 'node_modules', to: './vendor' }


### PR DESCRIPTION
_Replace options, including templates can now be optionally classified by category:_

![image](https://user-images.githubusercontent.com/58601/160406671-b11d3425-d61b-4f32-ae5c-a11a4d91ae7b.png)

Also, an additional _search_ meta-data allows to specify search terms not displayed through name, label or description.


----

Try it out via 

```
npx @bpmn-io/sr bpmn-io/bpmn-js-connectors-extension#template-categories-search -c 'npm start'
```

Enable _create/append anything modeling UX_ [via a feature toggle](http://localhost:8081/?aa=1).