### PR TITLE
feat(create-menu): improve positioning

### DIFF
--- a/src/ConnectorsExtension.js
+++ b/src/ConnectorsExtension.js
@@ -172,8 +172,9 @@ ConnectorsExtension.prototype.replaceAnything = function(event, element) {
   });
 };
 
-ConnectorsExtension.prototype.createAnything = function(event) {
-  return this._createMenu.open(event).then(result => {
+ConnectorsExtension.prototype.createAnything = function(event, position) {
+
+  return this._createMenu.open(event, position).then(result => {
 
     const {
       event: _event,
@@ -273,7 +274,16 @@ ConnectorsExtension.prototype.getPaletteEntries = function() {
       title: this._translate('Create anything'),
       action: {
         click: (event) => {
-          this.createAnything(event);
+
+          const cursor = event && { x: event.x, y: event.y };
+
+          const position = event && {
+            x: cursor.x + 35,
+            y: cursor.y + 10,
+            cursor
+          };
+
+          this.createAnything(event, position);
         }
       }
     }

--- a/src/create-menu/CreateMenu.js
+++ b/src/create-menu/CreateMenu.js
@@ -140,7 +140,7 @@ CreateMenu.prototype._getContext = function() {
  *
  * @return { Promise<CreateMenuResult> }
  */
-CreateMenu.prototype.open = function(position) {
+CreateMenu.prototype.open = function(event, position=event) {
 
   const {
     entries


### PR DESCRIPTION
Ensure it does not overlap with the create `...` on the palette, if triggered via mouse. This is in line with out other menus, that tend to not overlap with the invoking button.

![capture qtTnRZ_optimized](https://user-images.githubusercontent.com/58601/160829059-5e0d4e77-c5dd-4357-a385-7951d66d7bdd.gif)

---

Not relevant for connectors only modeling, as it is hidden via feature toggle.