### PR TITLE
fix: force create mode when appending boundary event

### DIFF
--- a/src/append-menu/AppendMenu.js
+++ b/src/append-menu/AppendMenu.js
@@ -75,7 +75,8 @@ AppendMenu.prototype._getDefaultEntries = function() {
       description,
       category,
       search,
-      rating
+      rating,
+      forceDragStart
     } = option;
 
     return {
@@ -88,7 +89,8 @@ AppendMenu.prototype._getDefaultEntries = function() {
       rating,
       action: () => {
         return this._elementFactory.create('shape', { ...target });
-      }
+      },
+      forceDragStart
     };
   });
 
@@ -212,12 +214,14 @@ function AppendMenuComponent(props) {
   } = props;
 
   const onSelect = (event, entry, dragstart = false) => {
+    const { forceDragStart } = entry;
+
     const newElement = entry.action();
 
     onClose({
       event,
       newElement,
-      dragstart
+      dragstart: dragstart || forceDragStart
     });
   };
 

--- a/src/create-menu/CreateMenu.js
+++ b/src/create-menu/CreateMenu.js
@@ -60,7 +60,8 @@ CreateMenu.prototype._getDefaultEntries = function() {
       category,
       search,
       rating,
-      target
+      target,
+      forceDragStart
     } = option;
 
     return {
@@ -72,7 +73,8 @@ CreateMenu.prototype._getDefaultEntries = function() {
       rating,
       action: () => {
         return this._elementFactory.create('shape', { ...target });
-      }
+      },
+      forceDragStart
     };
   });
 
@@ -179,12 +181,14 @@ function CreateMenuComponent(props) {
   } = props;
 
   const onSelect = (event, entry, dragstart = false) => {
+    const { forceDragStart } = entry;
+
     const newElement = entry.action();
 
     onClose({
       event,
       newElement,
-      dragstart
+      dragstart: dragstart || forceDragStart
     });
   };
 

--- a/src/create-menu/CreateOptions.js
+++ b/src/create-menu/CreateOptions.js
@@ -328,7 +328,7 @@ export var TYPED_BOUNDARY_EVENT = [
       cancelActivity: false
     }
   }
-].map(option => ({ ...option, category: EVENT_CATEGORY }));
+].map(option => ({ ...option, category: EVENT_CATEGORY, forceDragStart: true }));
 
 export var TYPED_END_EVENT = [
   {


### PR DESCRIPTION
Clicking boundary event will always force create mode instead of appending. It's still a bit confusing since we click boundary event but can also place it on the canvas turning it into an intermediate catch event.

![brave_DAIU2y1BbJ](https://user-images.githubusercontent.com/7633572/195781197-6d3ec060-e2c0-42d0-9a85-2849206e54a8.gif)

Alternatively, we could remove boundary events from the append menu but that would be inconsistent with the standard append behavior that lets you place an intermediate catch event on an activity to turn it into a boundary event.

---

Related to https://github.com/bpmn-io/bpmn-js/issues/1731
