### PR TITLE
Examples: Load templates in batch

### DIFF
--- a/example/.camunda/element-templates/dynamic-template-values.json
+++ b/example/.camunda/element-templates/dynamic-template-values.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+  "name": "Dynamic Template (different values)",
+  "id": "dynamic-template-different-values",
+  "appliesTo": [
+    "bpmn:Task"
+  ],
+  "properties": [
+    {
+      "id": "operation",
+      "label": "operation",
+      "description": "Operation to be done",
+      "type": "Dropdown",
+      "value": "action1",
+      "choices": [
+        {
+          "name": "Action 1",
+          "value": "action1"
+        },
+        {
+          "name": "Action 2",
+          "value": "action2"
+        },
+        {
+          "name": "Action 3",
+          "value": "action3"
+        }
+      ],
+      "binding": {
+        "type": "zeebe:input",
+        "name": "functionType"
+      },
+      "constraints": {
+        "notEmpty": true
+      }
+    },
+    {
+      "label": "Type",
+      "type": "String",
+      "value": "action1-value",
+      "binding": {
+        "type": "zeebe:taskDefinition:type"
+      },
+      "condition": {
+        "property": "operation",
+        "equals": "action1"
+      }
+    },
+    {
+      "label": "Type",
+      "type": "String",
+      "value": "action2-value",
+      "binding": {
+        "type": "zeebe:taskDefinition:type"
+      },
+      "condition": {
+        "property": "operation",
+        "equals": "action2"
+      }
+    },
+    {
+      "label": "Type",
+      "type": "String",
+      "value": "action3-value",
+      "binding": {
+        "type": "zeebe:taskDefinition:type"
+      },
+      "condition": {
+        "property": "operation",
+        "equals": "action3"
+      }
+    }
+  ]
+}

--- a/example/app.js
+++ b/example/app.js
@@ -25,29 +25,23 @@ import download from 'downloadjs';
 
 import exampleXML from './newDiagram.bpmn';
 
-import EMAIL_TEMPLATES from './.camunda/element-templates/sendgrid-connector.json';
-import REST_TEMPLATES from './.camunda/element-templates/http-json-connector.json';
-import HEADER_INPUT_TEMPLATES from './.camunda/element-templates/header-input.json';
-import SLACK_TEMPLATES from './.camunda/element-templates/slack-connector.json';
-import VERSIONED_TEMPLATES from './.camunda/element-templates/versioned.json';
-import MISC_TEMPLATES from './.camunda/element-templates/misc.json';
-import EMPTY_TEMPLATE from './.camunda/element-templates/empty.json';
-import DUE_DATE_TEMPLATE from './.camunda/element-templates/due-date.json';
-import GITHUB_WEBHOOK_TEMPLATE from './.camunda/element-templates/github-webhook.json';
+/**
+ * Load element templates under <.camunda/element-templates>
+ * dynamically.
+ *
+ * @return { object[] } element templates
+ */
+function loadTemplates() {
+
+  /* global require */
+  const context = require.context('./.camunda/element-templates/', false, /\.json$/);
+
+  return context.keys().map(key => context(key)).flat();
+}
 
 import './style.css';
 
-const TEMPLATES = [
-  ...EMAIL_TEMPLATES,
-  ...REST_TEMPLATES,
-  ...SLACK_TEMPLATES,
-  ...MISC_TEMPLATES,
-  ...HEADER_INPUT_TEMPLATES,
-  ...VERSIONED_TEMPLATES,
-  EMPTY_TEMPLATE,
-  DUE_DATE_TEMPLATE,
-  GITHUB_WEBHOOK_TEMPLATE
-];
+const TEMPLATES = loadTemplates();
 
 const url = new URL(window.location.href);
 


### PR DESCRIPTION
This PR makes it easier to add more element templates to the extension example.

Rather than

* Adding it to the `.camunda/element-templates` foldr
* Link in app

the files are now picked up automatically once added to the folder.